### PR TITLE
Add comprehensive API reference and documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,246 @@
-# Asciidoc to Word Converter
+# AsciiDoc to Word Converter
 
-This library converts Asciidoc document into Office 365 Word&reg; document. 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.md)
+[![Java](https://img.shields.io/badge/Java-17+-orange.svg)](https://www.oracle.com/java/)
+[![Gradle](https://img.shields.io/badge/Gradle-9.4.1-green.svg)](https://gradle.org/)
 
-## Implementation details
+A powerful library and command-line tool that converts AsciiDoc documents into Microsoft Word (DOCX) format. This tool uses DocBook as an intermediate format to ensure robust and accurate conversion while preserving document structure, formatting, and styling.
 
-A document can be divided into two type of elements:
+## Features
 
-**Inline:**
+- ✅ **Full AsciiDoc Support** - Comprehensive support for AsciiDoc elements
+- 📄 **DocBook Pipeline** - Reliable conversion via DocBook XML intermediate format
+- 🎨 **Rich Formatting** - Preserves text styles, lists, tables, admonitions, and more
+- 🌐 **Arabic Text Support** - Built-in support for Arabic text rendering
+- ⚡ **CLI Tool** - Easy-to-use command-line interface
+- 🔧 **Programmatic API** - Use as a library in your Java applications
+- 📦 **Shadow JAR** - Single executable JAR with all dependencies
 
-An inline element can be visualized as an element with certain visual markups, for example, bold, italic, monospace, and 
-more.
+## Quick Start
 
-**Block:**
+### Prerequisites
 
-A block element represents as a container with one or more inline elements.
+- Java 17 or higher
+- Gradle 9.4.1 (wrapper included)
 
-### Application building blocks
+### Building
 
+Clone and build the project:
+
+```bash
+git clone https://github.com/AlphaSystemSolution/docbook-2-docx.git
+cd docbook-2-docx
+./gradlew build
+```
+
+### Creating the CLI Tool
+
+Build the shadow JAR (fat JAR with all dependencies):
+
+```bash
+./gradlew :asciidoc-docx-cli:shadowJar
+```
+
+The executable JAR will be created at:
+```
+asciidoc-docx-cli/build/libs/asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar
+```
+
+### Basic Usage
+
+Convert an AsciiDoc file to Word:
+
+```bash
+java -jar asciidoc-docx-cli/build/libs/asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar -s input.adoc
+```
+
+This creates `input.docx` in the same directory as the source file.
+
+## Documentation
+
+📚 **Comprehensive documentation is available in the [docs](docs/) directory:**
+
+- **[Main Documentation](docs/index.adoc)** - Project overview and quick start
+- **[CLI User Guide](docs/cli-guide.adoc)** - Complete command-line reference
+- **[Developer Guide](docs/developer-guide.adoc)** - Architecture and contribution guidelines
+- **[API Reference](docs/api-reference.adoc)** - Programmatic usage
+- **[Supported Elements](docs/elements-reference.adoc)** - Complete element reference
+- **[Examples](docs/examples/)** - Sample AsciiDoc documents
+
+## Command-Line Options
+
+```bash
+java -jar asciidoc-docx-cli-{version}-all.jar [OPTIONS]
+
+Required:
+  -s <srcPath>              Source AsciiDoc file path
+
+Optional:
+  -d <destPath>             Destination DOCX file path
+  -o                        Open document after conversion
+  -e <extractPath>          Extract DOCX package to directory
+  -x <docbookPath>          Save intermediate DocBook XML
+```
+
+### Examples
+
+```bash
+# Basic conversion
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar -s document.adoc
+
+# Custom output path and auto-open
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar \
+  -s input.adoc \
+  -d output.docx \
+  -o
+
+# Debug mode with DocBook extraction
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar \
+  -s document.adoc \
+  -x ./debug \
+  -e ./extracted
+```
+
+## Project Structure
+
+The project is organized into six modules:
+
+```
+docbook-2-docx-parent/
+├── docbook-2-docx-common/     # Shared models and utilities
+├── docbook-model/             # JAXB-generated DocBook models
+├── asciidoctor-adapter/       # AsciiDoc to DocBook conversion
+├── docbook-2-docx/            # Core conversion engine
+├── arabic-handler/            # Arabic text support
+└── asciidoc-docx-cli/         # Command-line interface
+```
+
+## How It Works
+
+The conversion follows a three-stage pipeline:
+
+```
+AsciiDoc → DocBook XML → DOCX (Word)
+```
+
+1. **AsciiDoc to DocBook**: AsciidoctorJ converts AsciiDoc to DocBook XML
+2. **DocBook to DOCX**: Custom conversion engine transforms DocBook elements to Word structures
+3. **Output**: Fully formatted DOCX file ready for Microsoft Word
+
+## Programmatic Usage
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>io.github.sfali23</groupId>
+    <artifactId>asciidoctor-adapter</artifactId>
+    <version>0.5.5-SNAPSHOT</version>
+</dependency>
+<dependency>
+    <groupId>io.github.sfali23</groupId>
+    <artifactId>docbook-2-docx</artifactId>
+    <version>0.5.5-SNAPSHOT</version>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+dependencies {
+    implementation 'io.github.sfali23:asciidoctor-adapter:0.5.5-SNAPSHOT'
+    implementation 'io.github.sfali23:docbook-2-docx:0.5.5-SNAPSHOT'
+}
+```
+
+### Example Code
+
+```java
+import com.alphasystem.asciidoc.util.DocumentConverter;
+import com.alphasystem.docbook.DocumentBuilder;
+import java.nio.file.Paths;
+
+public class Example {
+    public static void main(String[] args) throws Exception {
+        // Convert AsciiDoc to DocBook
+        var docInfo = DocumentConverter.convertToDocBook(
+            Paths.get("input.adoc")
+        );
+        
+        // Convert DocBook to Word
+        var outputPath = DocumentBuilder.buildDocument(
+            docInfo.getDocumentInfo(),
+            Paths.get("output.docx")
+        );
+        
+        System.out.println("Created: " + outputPath);
+    }
+}
+```
+
+## Supported Elements
+
+The converter supports a comprehensive set of AsciiDoc elements:
+
+- **Block Elements**: Paragraphs, lists (ordered, unordered, definition), tables, code blocks, admonitions (note, tip, warning, caution, important), examples, sidebars
+- **Inline Elements**: Bold, italic, monospace, superscript, subscript, links, cross-references
+- **Special Features**: Arabic text support, custom styling, images, includes
+
+See the [Supported Elements Reference](docs/elements-reference.adoc) for complete details.
+
+## Development
+
+### Building from Source
+
+```bash
+./gradlew clean build
+```
+
+### Running Tests
+
+```bash
+./gradlew test
+```
+
+### Code Coverage
+
+```bash
+./gradlew test jacocoTestReport
+```
+
+Reports are generated in `build/reports/jacoco/test/html/`.
+
+## Contributing
+
+Contributions are welcome! Please see the [Developer Guide](docs/developer-guide.adoc) for:
+
+- Architecture overview
+- Development workflow
+- Code style guidelines
+- Testing requirements
+- Pull request process
+
+## License
+
+This project is licensed under the Apache License 2.0. See [LICENSE.md](LICENSE.md) for details.
+
+## Version
+
+Current version: **0.5.5-SNAPSHOT**
+
+## Links
+
+- **Documentation**: [docs/](docs/)
+- **Examples**: [docs/examples/](docs/examples/)
+- **Issues**: GitHub Issues
+- **AsciiDoc**: https://asciidoc.org/
+- **Asciidoctor**: https://asciidoctor.org/
+- **DocBook**: https://docbook.org/
+
+## Support
+
+For questions, issues, or contributions, please visit the project repository.
+
+---
+
+Made with ❤️ by the AlphaSystem team

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -1,0 +1,60 @@
+= Documentation Index
+:toc:
+:icons: font
+
+== Welcome to the Documentation
+
+This directory contains comprehensive documentation for the AsciiDoc to Word Converter project.
+
+== Documentation Files
+
+=== User Documentation
+
+* link:index.adoc[*Main Documentation*] - Project overview, quick start, and general information
+* link:cli-guide.adoc[*CLI User Guide*] - Complete command-line interface documentation with examples
+* link:elements-reference.adoc[*Supported Elements Reference*] - Comprehensive list of all supported AsciiDoc elements
+
+=== Developer Documentation
+
+* link:developer-guide.adoc[*Developer Guide*] - Architecture, modules, building, and contributing
+* link:api-reference.adoc[*API Reference*] - Programmatic usage and library integration
+
+== Example Documents
+
+The link:examples/[examples directory] contains sample AsciiDoc files:
+
+* link:examples/basic-example.adoc[*Basic Example*] - Simple document with common elements
+* link:examples/technical-doc.adoc[*Technical Documentation*] - REST API documentation example
+* link:examples/user-guide.adoc[*User Guide*] - Software user manual example
+
+== Converting Documentation to Word
+
+You can convert any of these AsciiDoc files to Word format using the CLI tool:
+
+[source,bash]
+----
+# Convert a documentation file
+java -jar ../asciidoc-docx-cli/build/libs/asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar \
+  -s index.adoc \
+  -d index.docx
+
+# Convert an example
+java -jar ../asciidoc-docx-cli/build/libs/asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar \
+  -s examples/basic-example.adoc
+----
+
+== Quick Links
+
+* link:../README.md[Project README]
+* link:../LICENSE.md[License]
+* https://github.com/AlphaSystemSolution/docbook-2-docx[GitHub Repository]
+
+== Contributing to Documentation
+
+To improve the documentation:
+
+. Edit the relevant `.adoc` file
+. Test the conversion to Word
+. Submit a pull request
+
+Documentation follows AsciiDoc best practices and uses consistent formatting throughout.

--- a/docs/api-reference.adoc
+++ b/docs/api-reference.adoc
@@ -1,0 +1,668 @@
+= API Reference
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+:source-highlighter: rouge
+
+== Introduction
+
+This guide covers programmatic usage of the AsciiDoc to Word Converter as a library in your Java applications.
+
+== Maven/Gradle Dependencies
+
+=== Gradle
+
+Add the following to your `build.gradle`:
+
+[source,groovy]
+----
+dependencies {
+    implementation 'io.github.sfali23:asciidoctor-adapter:0.5.5-SNAPSHOT'
+    implementation 'io.github.sfali23:docbook-2-docx:0.5.5-SNAPSHOT'
+}
+----
+
+For the complete CLI functionality:
+
+[source,groovy]
+----
+dependencies {
+    implementation 'io.github.sfali23:asciidoc-docx-cli:0.5.5-SNAPSHOT'
+}
+----
+
+=== Maven
+
+Add the following to your `pom.xml`:
+
+[source,xml]
+----
+<dependencies>
+    <dependency>
+        <groupId>io.github.sfali23</groupId>
+        <artifactId>asciidoctor-adapter</artifactId>
+        <version>0.5.5-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+        <groupId>io.github.sfali23</groupId>
+        <artifactId>docbook-2-docx</artifactId>
+        <version>0.5.5-SNAPSHOT</version>
+    </dependency>
+</dependencies>
+----
+
+== Core API Classes
+
+=== DocumentConverter
+
+The `DocumentConverter` class provides methods to convert AsciiDoc documents to DocBook XML.
+
+==== Package
+
+[source,java]
+----
+com.alphasystem.asciidoc.util.DocumentConverter
+----
+
+==== Methods
+
+===== convertDocument
+
+Loads and parses an AsciiDoc document without converting to DocBook.
+
+[source,java]
+----
+public static AsciiDocumentInfo convertDocument(Path srcPath)
+----
+
+*Parameters*:
+
+* `srcPath` - Path to the AsciiDoc source file
+
+*Returns*: `AsciiDocumentInfo` containing document metadata and attributes
+
+*Throws*: `NullPointerException` if the source file doesn't exist
+
+===== convertToDocBook
+
+Converts an AsciiDoc document to DocBook XML format.
+
+[source,java]
+----
+public static AsciiDocumentInfo convertToDocBook(Path srcPath) 
+    throws SystemException
+----
+
+*Parameters*:
+
+* `srcPath` - Path to the AsciiDoc source file
+
+*Returns*: `AsciiDocumentInfo` containing DocBook XML content
+
+*Throws*:
+
+* `SystemException` - If conversion fails
+* `NullPointerException` - If the source file doesn't exist
+
+==== Example Usage
+
+[source,java]
+----
+import com.alphasystem.asciidoc.util.DocumentConverter;
+import com.alphasystem.asciidoc.model.AsciiDocumentInfo;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Example {
+    public static void main(String[] args) {
+        Path srcPath = Paths.get("document.adoc");
+        
+        try {
+            // Convert to DocBook
+            AsciiDocumentInfo docInfo = 
+                DocumentConverter.convertToDocBook(srcPath);
+            
+            // Get DocBook XML content
+            String docBookXml = docInfo.getContent();
+            System.out.println(docBookXml);
+            
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}
+----
+
+=== DocumentBuilder
+
+The `DocumentBuilder` class converts DocBook XML to DOCX format.
+
+==== Package
+
+[source,java]
+----
+com.alphasystem.docbook.DocumentBuilder
+----
+
+==== Methods
+
+===== buildDocument (with custom path)
+
+Builds a Word document from DocBook content with a specified output path.
+
+[source,java]
+----
+public static Path buildDocument(
+    DocumentInfo documentInfo, 
+    Path docxPath
+) throws SystemException
+----
+
+*Parameters*:
+
+* `documentInfo` - Document metadata and DocBook content
+* `docxPath` - Output path for the DOCX file
+
+*Returns*: Path to the created DOCX file
+
+*Throws*: `SystemException` - If document generation fails
+
+===== buildDocument (default path)
+
+Builds a Word document with an automatically determined output path.
+
+[source,java]
+----
+public static Path buildDocument(DocumentInfo documentInfo) 
+    throws SystemException
+----
+
+*Parameters*:
+
+* `documentInfo` - Document metadata and DocBook content
+
+*Returns*: Path to the created DOCX file (same directory as source, `.docx` extension)
+
+*Throws*: `SystemException` - If document generation fails
+
+==== Example Usage
+
+[source,java]
+----
+import com.alphasystem.docbook.DocumentBuilder;
+import com.alphasystem.asciidoc.model.DocumentInfo;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Example {
+    public static void main(String[] args) {
+        try {
+            // Assuming you have DocumentInfo from DocumentConverter
+            DocumentInfo docInfo = getDocumentInfo();
+            
+            // Build with default path
+            Path outputPath = DocumentBuilder.buildDocument(docInfo);
+            System.out.println("Created: " + outputPath);
+            
+            // Or build with custom path
+            Path customPath = Paths.get("output/custom.docx");
+            Path result = DocumentBuilder.buildDocument(docInfo, customPath);
+            System.out.println("Created: " + result);
+            
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}
+----
+
+=== AsciiDocumentInfo
+
+Container for AsciiDoc document information and DocBook content.
+
+==== Package
+
+[source,java]
+----
+com.alphasystem.asciidoc.model.AsciiDocumentInfo
+----
+
+==== Key Methods
+
+[source,java]
+----
+// Get DocBook XML content
+String getContent()
+
+// Get document metadata
+DocumentInfo getDocumentInfo()
+
+// Get source file
+File getSrcFile()
+
+// Get backend type
+String getBackend()
+
+// Set DocBook content
+void setContent(String content)
+----
+
+==== Example
+
+[source,java]
+----
+AsciiDocumentInfo docInfo = DocumentConverter.convertToDocBook(srcPath);
+
+// Access properties
+String docBookXml = docInfo.getContent();
+File sourceFile = docInfo.getDocumentInfo().getSrcFile();
+String backend = docInfo.getBackend(); // "docbook"
+----
+
+== Complete Conversion Example
+
+=== Basic Conversion
+
+[source,java]
+----
+import com.alphasystem.asciidoc.util.DocumentConverter;
+import com.alphasystem.docbook.DocumentBuilder;
+import com.alphasystem.asciidoc.model.AsciiDocumentInfo;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class AsciiDocToWordConverter {
+    
+    public static void convertToWord(String inputPath, String outputPath) {
+        try {
+            // Step 1: Convert AsciiDoc to DocBook
+            Path srcPath = Paths.get(inputPath);
+            AsciiDocumentInfo docInfo = 
+                DocumentConverter.convertToDocBook(srcPath);
+            
+            // Step 2: Convert DocBook to Word
+            Path docxPath = Paths.get(outputPath);
+            Path result = DocumentBuilder.buildDocument(
+                docInfo.getDocumentInfo(), 
+                docxPath
+            );
+            
+            System.out.println("Successfully created: " + result);
+            
+        } catch (Exception e) {
+            System.err.println("Conversion failed: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+    
+    public static void main(String[] args) {
+        convertToWord("input.adoc", "output.docx");
+    }
+}
+----
+
+=== Conversion with Error Handling
+
+[source,java]
+----
+import com.alphasystem.asciidoc.util.DocumentConverter;
+import com.alphasystem.docbook.DocumentBuilder;
+import com.alphasystem.commons.SystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RobustConverter {
+    
+    public static boolean convert(String input, String output) {
+        Path srcPath = Paths.get(input);
+        
+        // Validate input
+        if (!Files.exists(srcPath)) {
+            System.err.println("Input file not found: " + input);
+            return false;
+        }
+        
+        if (!Files.isRegularFile(srcPath)) {
+            System.err.println("Input is not a file: " + input);
+            return false;
+        }
+        
+        try {
+            // Convert to DocBook
+            var docInfo = DocumentConverter.convertToDocBook(srcPath);
+            
+            // Validate DocBook content
+            if (docInfo.getContent() == null || 
+                docInfo.getContent().isEmpty()) {
+                System.err.println("DocBook conversion produced no content");
+                return false;
+            }
+            
+            // Convert to Word
+            Path docxPath = Paths.get(output);
+            
+            // Ensure output directory exists
+            Path parentDir = docxPath.getParent();
+            if (parentDir != null && !Files.exists(parentDir)) {
+                Files.createDirectories(parentDir);
+            }
+            
+            Path result = DocumentBuilder.buildDocument(
+                docInfo.getDocumentInfo(), 
+                docxPath
+            );
+            
+            // Verify output
+            if (Files.exists(result) && Files.size(result) > 0) {
+                System.out.println("Success: " + result);
+                return true;
+            } else {
+                System.err.println("Output file was not created properly");
+                return false;
+            }
+            
+        } catch (SystemException e) {
+            System.err.println("Conversion error: " + e.getMessage());
+            return false;
+        } catch (Exception e) {
+            System.err.println("Unexpected error: " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+}
+----
+
+=== Batch Conversion
+
+[source,java]
+----
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.stream.Stream;
+
+public class BatchConverter {
+    
+    public static void convertDirectory(String inputDir, String outputDir) 
+            throws IOException {
+        Path inPath = Paths.get(inputDir);
+        Path outPath = Paths.get(outputDir);
+        
+        // Create output directory if needed
+        if (!Files.exists(outPath)) {
+            Files.createDirectories(outPath);
+        }
+        
+        // Find all .adoc files
+        try (Stream<Path> paths = Files.walk(inPath)) {
+            paths.filter(Files::isRegularFile)
+                 .filter(p -> p.toString().endsWith(".adoc"))
+                 .forEach(srcFile -> {
+                     try {
+                         // Determine output filename
+                         String filename = srcFile.getFileName()
+                                                  .toString()
+                                                  .replace(".adoc", ".docx");
+                         Path destFile = outPath.resolve(filename);
+                         
+                         // Convert
+                         System.out.println("Converting: " + srcFile);
+                         var docInfo = DocumentConverter
+                             .convertToDocBook(srcFile);
+                         DocumentBuilder.buildDocument(
+                             docInfo.getDocumentInfo(), 
+                             destFile
+                         );
+                         System.out.println("Created: " + destFile);
+                         
+                     } catch (Exception e) {
+                         System.err.println(
+                             "Failed to convert " + srcFile + ": " + 
+                             e.getMessage()
+                         );
+                     }
+                 });
+        }
+    }
+    
+    public static void main(String[] args) throws IOException {
+        convertDirectory("./docs", "./output");
+    }
+}
+----
+
+=== Saving Intermediate DocBook
+
+[source,java]
+----
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class DebugConverter {
+    
+    public static void convertWithDebug(
+            String input, 
+            String output, 
+            String debugDir
+    ) throws Exception {
+        Path srcPath = Paths.get(input);
+        
+        // Convert to DocBook
+        var docInfo = DocumentConverter.convertToDocBook(srcPath);
+        
+        // Save DocBook XML for debugging
+        if (debugDir != null) {
+            Path debugPath = Paths.get(debugDir);
+            if (!Files.exists(debugPath)) {
+                Files.createDirectories(debugPath);
+            }
+            
+            String xmlFilename = srcPath.getFileName()
+                                        .toString()
+                                        .replace(".adoc", ".xml");
+            Path xmlPath = debugPath.resolve(xmlFilename);
+            
+            Files.writeString(xmlPath, docInfo.getContent());
+            System.out.println("Saved DocBook XML: " + xmlPath);
+        }
+        
+        // Convert to Word
+        Path docxPath = Paths.get(output);
+        DocumentBuilder.buildDocument(
+            docInfo.getDocumentInfo(), 
+            docxPath
+        );
+        System.out.println("Created DOCX: " + docxPath);
+    }
+    
+    public static void main(String[] args) throws Exception {
+        convertWithDebug(
+            "document.adoc", 
+            "document.docx", 
+            "./debug"
+        );
+    }
+}
+----
+
+== Advanced Usage
+
+=== Custom Document Processing
+
+[source,java]
+----
+import com.alphasystem.asciidoc.util.DocumentConverter;
+import com.alphasystem.asciidoc.model.AsciiDocumentInfo;
+import java.nio.file.Path;
+
+public class CustomProcessor {
+    
+    public static void processDocument(Path srcPath) throws Exception {
+        // Load document
+        AsciiDocumentInfo docInfo = 
+            DocumentConverter.convertDocument(srcPath);
+        
+        // Access document attributes
+        var document = docInfo.getDocument();
+        if (document != null) {
+            // Process attributes
+            var attributes = document.getAttributes();
+            System.out.println("Title: " + attributes.get("doctitle"));
+            System.out.println("Author: " + attributes.get("author"));
+            
+            // Custom processing based on attributes
+            if (attributes.containsKey("custom-style")) {
+                // Apply custom styling
+            }
+        }
+        
+        // Convert to DocBook with custom options
+        AsciiDocumentInfo docBookInfo = 
+            DocumentConverter.convertToDocBook(srcPath);
+        
+        // Post-process DocBook content
+        String docBook = docBookInfo.getContent();
+        String modified = postProcessDocBook(docBook);
+        docBookInfo.setContent(modified);
+        
+        // Convert to Word
+        DocumentBuilder.buildDocument(docBookInfo.getDocumentInfo());
+    }
+    
+    private static String postProcessDocBook(String docBook) {
+        // Custom DocBook transformations
+        return docBook;
+    }
+}
+----
+
+=== Integration with Spring Boot
+
+[source,java]
+----
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Service
+public class ConversionService {
+    
+    public Path convertAsciiDocToWord(MultipartFile file) 
+            throws Exception {
+        // Save uploaded file
+        Path tempInput = Files.createTempFile("input", ".adoc");
+        file.transferTo(tempInput.toFile());
+        
+        try {
+            // Convert to DocBook
+            var docInfo = DocumentConverter.convertToDocBook(tempInput);
+            
+            // Create output file
+            Path tempOutput = Files.createTempFile("output", ".docx");
+            
+            // Convert to Word
+            return DocumentBuilder.buildDocument(
+                docInfo.getDocumentInfo(), 
+                tempOutput
+            );
+            
+        } finally {
+            // Cleanup
+            Files.deleteIfExists(tempInput);
+        }
+    }
+}
+----
+
+== Exception Handling
+
+=== SystemException
+
+The main exception thrown by the conversion API.
+
+[source,java]
+----
+try {
+    DocumentBuilder.buildDocument(docInfo);
+} catch (SystemException e) {
+    // Conversion failed
+    System.err.println("Error: " + e.getMessage());
+    Throwable cause = e.getCause();
+    if (cause != null) {
+        System.err.println("Caused by: " + cause.getMessage());
+    }
+}
+----
+
+=== Common Exceptions
+
+* `NullPointerException` - Source file doesn't exist
+* `SystemException` - Conversion error
+* `IOException` - File I/O error
+* `Docx4JException` - Word document generation error
+
+== Performance Considerations
+
+=== Memory Usage
+
+For large documents, consider:
+
+[source,java]
+----
+// Increase heap size when running
+// -Xmx2g or higher
+
+// Process in batches
+List<Path> files = getLargeFileList();
+for (Path file : files) {
+    convertFile(file);
+    // Allow garbage collection between files
+    System.gc();
+}
+----
+
+=== Parallel Processing
+
+[source,java]
+----
+import java.util.concurrent.*;
+
+public class ParallelConverter {
+    
+    public static void convertParallel(List<Path> files) {
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        
+        List<Future<Path>> futures = files.stream()
+            .map(file -> executor.submit(() -> {
+                var docInfo = DocumentConverter.convertToDocBook(file);
+                return DocumentBuilder.buildDocument(
+                    docInfo.getDocumentInfo()
+                );
+            }))
+            .toList();
+        
+        // Wait for completion
+        futures.forEach(future -> {
+            try {
+                Path result = future.get();
+                System.out.println("Completed: " + result);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        
+        executor.shutdown();
+    }
+}
+----
+
+== See Also
+
+* link:index.adoc[Main Documentation]
+* link:cli-guide.adoc[CLI User Guide]
+* link:developer-guide.adoc[Developer Guide]
+* link:elements-reference.adoc[Supported Elements]

--- a/docs/cli-guide.adoc
+++ b/docs/cli-guide.adoc
@@ -1,0 +1,361 @@
+= CLI User Guide
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+:source-highlighter: rouge
+
+== Introduction
+
+The AsciiDoc to Word CLI tool provides a command-line interface for converting AsciiDoc documents to Microsoft Word (DOCX) format. This guide covers installation, usage, and troubleshooting.
+
+== Installation
+
+=== Building the Shadow JAR
+
+The CLI tool is distributed as a "shadow JAR" (also known as a fat JAR or uber JAR), which includes all dependencies in a single executable file.
+
+To build the shadow JAR:
+
+[source,bash]
+----
+cd docbook-2-docx
+./gradlew :asciidoc-docx-cli:shadowJar
+----
+
+The JAR file will be created at:
+----
+asciidoc-docx-cli/build/libs/asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar
+----
+
+=== System Requirements
+
+* *Java*: Version 17 or higher
+* *Operating System*: Windows, macOS, or Linux
+* *Memory*: Minimum 512MB RAM (1GB+ recommended for large documents)
+
+=== Verifying Installation
+
+Test the installation by running:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar
+----
+
+You should see the usage help message.
+
+== Command-Line Options
+
+=== Overview
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-{version}-all.jar [OPTIONS]
+----
+
+=== Required Options
+
+==== `-s <srcPath>` - Source File Path
+
+Specifies the path to the source AsciiDoc file.
+
+[source,bash]
+----
+-s /path/to/document.adoc
+----
+
+[NOTE]
+====
+This option is *required*. The file must exist and be readable.
+====
+
+=== Optional Options
+
+==== `-d <destPath>` - Destination File Path
+
+Specifies the output path for the generated DOCX file.
+
+[source,bash]
+----
+-d /path/to/output.docx
+----
+
+[TIP]
+====
+If not specified, the output file will be created in the same directory as the source file with a `.docx` extension.
+====
+
+==== `-o` - Open Document
+
+Automatically opens the generated document in the default application after conversion.
+
+[source,bash]
+----
+-o
+----
+
+[WARNING]
+====
+This option requires a desktop environment. It may not work in headless server environments.
+====
+
+==== `-e <extractedDocumentPath>` - Extract Package
+
+Extracts the DOCX package (which is a ZIP archive) to the specified directory for inspection.
+
+[source,bash]
+----
+-e /path/to/extract/directory
+----
+
+[NOTE]
+====
+This is useful for debugging or examining the internal structure of the generated Word document. The directory will be created if it doesn't exist, or cleaned if it does.
+====
+
+==== `-x <saveDocBookContent>` - Save DocBook Content
+
+Saves the intermediate DocBook XML content to a file in the specified directory.
+
+[source,bash]
+----
+-x /path/to/docbook/directory
+----
+
+[TIP]
+====
+Use this option to debug conversion issues or to examine the intermediate DocBook representation.
+====
+
+== Usage Examples
+
+=== Basic Conversion
+
+Convert an AsciiDoc file to Word using default settings:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar \
+  -s my-document.adoc
+----
+
+*Result*: Creates `my-document.docx` in the same directory.
+
+=== Custom Output Path
+
+Specify a custom output location:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar \
+  -s ~/Documents/source.adoc \
+  -d ~/Desktop/output.docx
+----
+
+=== Auto-Open Document
+
+Convert and automatically open the result:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar \
+  -s report.adoc \
+  -o
+----
+
+=== Debug Mode with DocBook Extraction
+
+Save the intermediate DocBook XML for debugging:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar \
+  -s document.adoc \
+  -x ./debug \
+  -e ./extracted
+----
+
+This will:
+
+1. Convert `document.adoc` to `document.docx`
+2. Save the DocBook XML to `./debug/document.xml`
+3. Extract the DOCX package contents to `./extracted/`
+
+=== Complete Workflow Example
+
+A comprehensive example using all options:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar \
+  -s /home/user/docs/manual.adoc \
+  -d /home/user/output/manual-v1.docx \
+  -x /home/user/debug \
+  -e /home/user/extracted \
+  -o
+----
+
+== Batch Processing
+
+=== Processing Multiple Files (Bash)
+
+[source,bash]
+----
+#!/bin/bash
+for file in *.adoc; do
+  java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar -s "$file"
+done
+----
+
+=== Processing Multiple Files (PowerShell)
+
+[source,powershell]
+----
+Get-ChildItem -Filter *.adoc | ForEach-Object {
+  java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar -s $_.FullName
+}
+----
+
+== Troubleshooting
+
+=== Common Errors
+
+==== "Missing required option: s"
+
+*Cause*: The `-s` option was not provided.
+
+*Solution*: Always specify the source file with `-s`:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar -s document.adoc
+----
+
+==== "Source path does not exists"
+
+*Cause*: The specified source file cannot be found.
+
+*Solution*: Verify the file path is correct and the file exists:
+
+[source,bash]
+----
+ls -l /path/to/file.adoc
+----
+
+==== "Unable save DocBook content"
+
+*Cause*: The directory specified with `-x` is not writable or doesn't exist.
+
+*Solution*: Ensure the directory exists and has write permissions:
+
+[source,bash]
+----
+mkdir -p /path/to/docbook
+chmod 755 /path/to/docbook
+----
+
+==== OutOfMemoryError
+
+*Cause*: Large documents may require more memory.
+
+*Solution*: Increase the Java heap size:
+
+[source,bash]
+----
+java -Xmx2g -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar -s large-doc.adoc
+----
+
+=== File Path Issues
+
+==== Spaces in Paths
+
+Always quote paths containing spaces:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar \
+  -s "My Documents/report.adoc" \
+  -d "My Documents/report.docx"
+----
+
+==== Relative vs Absolute Paths
+
+Both relative and absolute paths are supported:
+
+[source,bash]
+----
+# Relative path
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar -s ./docs/file.adoc
+
+# Absolute path
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar -s /home/user/docs/file.adoc
+----
+
+=== Getting Help
+
+Display usage information:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar
+----
+
+== Performance Tips
+
+=== Large Documents
+
+For large documents (>100 pages):
+
+1. Increase heap size: `-Xmx2g` or higher
+2. Process in sections if possible
+3. Disable auto-open (`-o`) to save time
+
+=== Batch Processing
+
+When processing many files:
+
+1. Use a shell script for automation
+2. Consider parallel processing for independent files
+3. Monitor memory usage
+
+== Advanced Usage
+
+=== Creating an Alias (Unix/Linux/macOS)
+
+Add to your `.bashrc` or `.zshrc`:
+
+[source,bash]
+----
+alias adoc2docx='java -jar /path/to/asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar'
+----
+
+Then use:
+
+[source,bash]
+----
+adoc2docx -s document.adoc -o
+----
+
+=== Windows Batch File
+
+Create `adoc2docx.bat`:
+
+[source,batch]
+----
+@echo off
+java -jar "C:\path\to\asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar" %*
+----
+
+Then use:
+
+[source,cmd]
+----
+adoc2docx -s document.adoc -o
+----
+
+== See Also
+
+* link:index.adoc[Main Documentation]
+* link:elements-reference.adoc[Supported Elements Reference]
+* link:api-reference.adoc[API Reference]

--- a/docs/developer-guide.adoc
+++ b/docs/developer-guide.adoc
@@ -1,0 +1,689 @@
+= Developer Guide
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+:source-highlighter: rouge
+
+== Introduction
+
+This guide provides comprehensive information for developers who want to contribute to the AsciiDoc to Word Converter project or understand its internal architecture.
+
+== Project Structure
+
+The project is organized as a multi-module Gradle build with six distinct modules:
+
+[source]
+----
+docbook-2-docx-parent/
+├── docbook-2-docx-common/     # Shared models and utilities
+├── docbook-model/             # JAXB-generated DocBook models
+├── asciidoctor-adapter/       # AsciiDoc to DocBook conversion
+├── docbook-2-docx/            # Core conversion engine
+├── arabic-handler/            # Arabic text support
+└── asciidoc-docx-cli/         # Command-line interface
+----
+
+=== Module Dependencies
+
+[source]
+----
+asciidoc-docx-cli
+    ├── asciidoctor-adapter
+    │   └── docbook-2-docx-common
+    ├── docbook-2-docx
+    │   ├── docbook-model
+    │   └── docbook-2-docx-common
+    └── arabic-handler
+----
+
+== Module Details
+
+=== docbook-2-docx-common
+
+*Purpose*: Shared models, utilities, and common interfaces used across modules.
+
+*Key Classes*:
+
+* `DocumentInfo` - Base document metadata and configuration
+* `Backend` - Enumeration of supported backends (DocBook, etc.)
+
+*Dependencies*: Minimal - only common utilities
+
+=== docbook-model
+
+*Purpose*: JAXB-generated Java classes representing the DocBook XML schema.
+
+*Generation*: Classes are generated from DocBook XSD schemas using the JAXB XJC compiler.
+
+*Key Packages*:
+
+* `org.docbook.model` - All DocBook element classes
+
+*Note*: This module is auto-generated. Do not manually edit classes in this module.
+
+=== asciidoctor-adapter
+
+*Purpose*: Converts AsciiDoc documents to DocBook XML format using AsciidoctorJ.
+
+*Key Classes*:
+
+* `DocumentConverter` - Main conversion entry point
+* `AsciiDocumentInfo` - Extended document info with AsciiDoc-specific metadata
+
+*Dependencies*:
+
+* AsciidoctorJ {asciidoctorjVersion}
+* docbook-2-docx-common
+
+*Conversion Process*:
+
+1. Load AsciiDoc file using AsciidoctorJ
+2. Extract document attributes and metadata
+3. Convert to DocBook XML using AsciidoctorJ's DocBook backend
+4. Return `AsciiDocumentInfo` with DocBook content
+
+=== docbook-2-docx
+
+*Purpose*: Core conversion engine that transforms DocBook XML into DOCX (Word) format.
+
+*Architecture*: Uses the Builder pattern to convert DocBook elements to Word structures.
+
+*Key Components*:
+
+==== ApplicationController
+
+Manages the conversion context and lifecycle.
+
+[source,java]
+----
+ApplicationController.startContext(documentInfo);
+try {
+    // Conversion logic
+} finally {
+    ApplicationController.endContext();
+}
+----
+
+==== DocumentBuilder
+
+Main entry point for DocBook to DOCX conversion.
+
+[source,java]
+----
+Path buildDocument(DocumentInfo documentInfo)
+Path buildDocument(DocumentInfo documentInfo, Path docxPath)
+----
+
+==== Builder Pattern
+
+Each DocBook element has a corresponding builder:
+
+* *Block Builders*: Para, List, Table, Admonition, etc.
+* *Inline Builders*: Emphasis, Link, Literal, etc.
+
+*Base Classes*:
+
+* `AbstractBuilder` - Base for all builders
+* `BlockBuilder` - Base for block-level elements
+* `InlineBuilder` - Base for inline elements
+
+==== Handler Pattern
+
+Handlers apply formatting to text runs:
+
+* `BoldHandler` - Bold text
+* `ItalicHandler` - Italic text
+* `ColorHandler` - Text color
+* `HighlightHandler` - Background highlighting
+* `HyperlinkHandler` - Hyperlinks
+
+=== arabic-handler
+
+*Purpose*: Provides specialized support for Arabic text rendering and processing.
+
+*Features*:
+
+* Right-to-left text direction
+* Arabic character shaping
+* Proper font handling
+
+=== asciidoc-docx-cli
+
+*Purpose*: Command-line interface for the conversion tool.
+
+*Main Class*: `com.alphasystem.docx.cli.Main`
+
+*Features*:
+
+* Apache Commons CLI for argument parsing
+* File path validation
+* Document extraction and debugging options
+
+== Building the Project
+
+=== Prerequisites
+
+* JDK 17 or higher
+* Gradle 9.4.1 (wrapper included)
+
+=== Build Commands
+
+==== Full Build
+
+[source,bash]
+----
+./gradlew build
+----
+
+This will:
+
+1. Compile all modules
+2. Run tests
+3. Generate JARs
+4. Run code quality checks
+
+==== Clean Build
+
+[source,bash]
+----
+./gradlew clean build
+----
+
+==== Build Specific Module
+
+[source,bash]
+----
+./gradlew :docbook-2-docx:build
+----
+
+==== Skip Tests
+
+[source,bash]
+----
+./gradlew build -x test
+----
+
+==== Create Shadow JAR
+
+[source,bash]
+----
+./gradlew :asciidoc-docx-cli:shadowJar
+----
+
+=== Running Tests
+
+==== All Tests
+
+[source,bash]
+----
+./gradlew test
+----
+
+==== Specific Module Tests
+
+[source,bash]
+----
+./gradlew :docbook-2-docx:test
+----
+
+==== Test with Coverage
+
+[source,bash]
+----
+./gradlew test jacocoTestReport
+----
+
+Coverage reports are generated in `build/reports/jacoco/test/html/`.
+
+== Architecture
+
+=== Conversion Pipeline
+
+The conversion follows a three-stage pipeline:
+
+[source]
+----
+┌─────────────┐      ┌──────────────┐      ┌─────────────┐
+│  AsciiDoc   │ ───> │ DocBook XML  │ ───> │    DOCX     │
+│   (.adoc)   │      │    (.xml)    │      │   (.docx)   │
+└─────────────┘      └──────────────┘      └─────────────┘
+     Stage 1              Stage 2              Stage 3
+  AsciidoctorJ      Custom Conversion      docx4j Library
+----
+
+==== Stage 1: AsciiDoc to DocBook
+
+* *Component*: `asciidoctor-adapter`
+* *Library*: AsciidoctorJ
+* *Process*: Uses AsciidoctorJ's built-in DocBook backend
+
+==== Stage 2: DocBook to Word Structures
+
+* *Component*: `docbook-2-docx`
+* *Pattern*: Builder pattern
+* *Process*: Each DocBook element is converted by a specialized builder
+
+==== Stage 3: Word Document Generation
+
+* *Library*: docx4j
+* *Process*: Word structures are serialized to DOCX format
+
+=== Design Patterns
+
+==== Builder Pattern
+
+Each DocBook element type has a dedicated builder class:
+
+[source,java]
+----
+public interface Builder<T> {
+    List<Object> buildInternal(T source);
+}
+----
+
+Example builders:
+
+* `ParaBuilder` - Converts `<para>` elements
+* `TableBuilder` - Converts `<table>` elements
+* `EmphasisBuilder` - Converts `<emphasis>` elements
+
+==== Factory Pattern
+
+`BuilderFactory` creates appropriate builders for each element type:
+
+[source,java]
+----
+Builder<?> builder = BuilderFactory.getBuilder(docBookElement);
+List<Object> wordElements = builder.buildInternal(docBookElement);
+----
+
+==== Handler Pattern
+
+Handlers apply formatting to text runs:
+
+[source,java]
+----
+public interface Handler {
+    void handle(R run, Object source);
+}
+----
+
+==== Context Pattern
+
+`DocumentContext` maintains conversion state:
+
+* Current document metadata
+* Style definitions
+* Cross-reference mappings
+* Configuration options
+
+=== Element Conversion
+
+==== Block Elements
+
+Block elements are converted to Word paragraphs or tables:
+
+[source,java]
+----
+public class ParaBuilder extends BlockBuilder<Para> {
+    @Override
+    public List<Object> buildInternal(Para source) {
+        P paragraph = new P();
+        // Process inline content
+        // Apply paragraph styles
+        return List.of(paragraph);
+    }
+}
+----
+
+==== Inline Elements
+
+Inline elements are converted to Word runs within paragraphs:
+
+[source,java]
+----
+public class EmphasisBuilder extends InlineBuilder<Emphasis> {
+    @Override
+    public List<Object> buildInternal(Emphasis source) {
+        R run = new R();
+        // Apply italic formatting
+        // Process text content
+        return List.of(run);
+    }
+}
+----
+
+==== Tables
+
+Tables are converted to Word table structures:
+
+* `<table>` → `Tbl`
+* `<thead>` → Table header rows
+* `<tbody>` → Table body rows
+* `<row>` → `Tr`
+* `<entry>` → `Tc`
+
+== Development Workflow
+
+=== Setting Up Development Environment
+
+1. Clone the repository:
++
+[source,bash]
+----
+git clone https://github.com/AlphaSystemSolution/docbook-2-docx.git
+cd docbook-2-docx
+----
+
+2. Import into your IDE (IntelliJ IDEA, Eclipse, VS Code)
+
+3. Build the project:
++
+[source,bash]
+----
+./gradlew build
+----
+
+=== Making Changes
+
+1. Create a feature branch:
++
+[source,bash]
+----
+git checkout -b feature/my-new-feature
+----
+
+2. Make your changes
+
+3. Run tests:
++
+[source,bash]
+----
+./gradlew test
+----
+
+4. Commit your changes:
++
+[source,bash]
+----
+git add .
+git commit -m "Add new feature"
+----
+
+=== Code Style
+
+* Follow standard Java conventions
+* Use meaningful variable and method names
+* Add Javadoc comments for public APIs
+* Keep methods focused and concise
+* Use builder pattern for complex object construction
+
+=== Testing Guidelines
+
+* Write unit tests for new functionality
+* Maintain or improve code coverage
+* Test edge cases and error conditions
+* Use descriptive test method names
+
+Example test structure:
+
+[source,java]
+----
+@Test
+public void testParaConversion() {
+    // Given
+    Para para = createTestPara();
+    
+    // When
+    List<Object> result = builder.buildInternal(para);
+    
+    // Then
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    assertTrue(result.get(0) instanceof P);
+}
+----
+
+== Adding New Features
+
+=== Adding Support for a New DocBook Element
+
+1. Create a new builder class in the appropriate package:
++
+[source,java]
+----
+public class MyElementBuilder extends BlockBuilder<MyElement> {
+    @Override
+    public List<Object> buildInternal(MyElement source) {
+        // Conversion logic
+    }
+}
+----
+
+2. Register the builder in `BuilderFactory`
+
+3. Add tests for the new builder
+
+4. Update documentation
+
+=== Adding a New Text Handler
+
+1. Create a handler class:
++
+[source,java]
+----
+public class MyHandler implements Handler {
+    @Override
+    public void handle(R run, Object source) {
+        // Formatting logic
+    }
+}
+----
+
+2. Register the handler in the handler registry
+
+3. Add tests
+
+=== Customizing Styles
+
+Styles are defined in configuration files. To add custom styles:
+
+1. Define the style in the style configuration
+2. Apply the style in the appropriate builder
+3. Test the style application
+
+== Debugging
+
+=== Enabling Debug Output
+
+Use the `-x` option to save intermediate DocBook XML:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli.jar -s input.adoc -x ./debug
+----
+
+=== Examining DOCX Structure
+
+Use the `-e` option to extract the DOCX package:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli.jar -s input.adoc -e ./extracted
+----
+
+The extracted directory contains:
+
+* `word/document.xml` - Main document content
+* `word/styles.xml` - Style definitions
+* `word/_rels/` - Relationships
+* `[Content_Types].xml` - Content type mappings
+
+=== Common Debugging Scenarios
+
+==== Element Not Converting
+
+1. Check if builder exists for the element
+2. Verify builder is registered in `BuilderFactory`
+3. Add logging to the builder
+4. Examine intermediate DocBook XML
+
+==== Formatting Issues
+
+1. Check handler implementation
+2. Verify style definitions
+3. Examine generated `word/document.xml`
+
+==== Performance Issues
+
+1. Profile with JProfiler or VisualVM
+2. Check for unnecessary object creation
+3. Optimize builder implementations
+
+== Publishing
+
+=== Maven Central
+
+The project is published to Maven Central via Sonatype OSSRH.
+
+Configuration:
+
+* Group ID: `io.github.sfali23`
+* Artifact IDs: Module names
+* Version: Defined in `gradle.properties`
+
+=== Release Process
+
+1. Update version in `gradle.properties`
+2. Build and test:
++
+[source,bash]
+----
+./gradlew clean build
+----
+
+3. Publish to staging:
++
+[source,bash]
+----
+./gradlew publishToSonatype
+----
+
+4. Close and release staging repository:
++
+[source,bash]
+----
+./gradlew closeAndReleaseSonatypeStagingRepository
+----
+
+== Contributing
+
+=== Pull Request Process
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests
+5. Update documentation
+6. Submit a pull request
+
+=== Code Review Guidelines
+
+* Code must pass all tests
+* Code coverage should not decrease
+* Follow existing code style
+* Include meaningful commit messages
+* Update documentation as needed
+
+== Dependencies
+
+=== Key Dependencies
+
+[cols="1,1,2"]
+|===
+|Library |Version |Purpose
+
+|AsciidoctorJ
+|{asciidoctorjVersion}
+|AsciiDoc processing
+
+|docx4j
+|Varies
+|Word document generation
+
+|JAXB
+|{jaxbRuntimeVersion}
+|XML binding
+
+|Commons CLI
+|{commonsCliVersion}
+|Command-line parsing
+
+|Guice
+|{guiceVersion}
+|Dependency injection
+
+|Logback
+|{logbackClassicVersion}
+|Logging
+|===
+
+=== Updating Dependencies
+
+Dependencies are defined in `gradle.properties`. To update:
+
+1. Modify version in `gradle.properties`
+2. Test thoroughly
+3. Update documentation if API changes
+
+== Troubleshooting
+
+=== Build Issues
+
+==== Gradle Version Mismatch
+
+Ensure you're using the wrapper:
+
+[source,bash]
+----
+./gradlew --version
+----
+
+==== Dependency Resolution Failures
+
+Clear Gradle cache:
+
+[source,bash]
+----
+./gradlew clean --refresh-dependencies
+----
+
+=== Runtime Issues
+
+==== ClassNotFoundException
+
+Ensure all dependencies are included in the shadow JAR:
+
+[source,bash]
+----
+./gradlew :asciidoc-docx-cli:shadowJar
+----
+
+==== OutOfMemoryError
+
+Increase heap size:
+
+[source,bash]
+----
+export GRADLE_OPTS="-Xmx2g"
+./gradlew build
+----
+
+== Resources
+
+* link:index.adoc[Main Documentation]
+* link:api-reference.adoc[API Reference]
+* link:cli-guide.adoc[CLI Guide]
+* https://asciidoctor.org/[Asciidoctor Documentation]
+* https://www.docbook.org/[DocBook Documentation]

--- a/docs/elements-reference.adoc
+++ b/docs/elements-reference.adoc
@@ -1,0 +1,779 @@
+= Supported Elements Reference
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+:source-highlighter: rouge
+
+== Introduction
+
+This reference documents all AsciiDoc elements supported by the AsciiDoc to Word Converter. Each element is shown with its AsciiDoc syntax and the resulting Word output.
+
+== Document Structure
+
+=== Document Title
+
+[cols="1,2"]
+|===
+|AsciiDoc |Word Output
+
+a|
+[source,asciidoc]
+----
+= Document Title
+----
+|Document title in Title style
+
+a|
+[source,asciidoc]
+----
+= Main Title
+:author: John Doe
+:email: john@example.com
+----
+|Title with author metadata
+|===
+
+=== Sections
+
+[cols="1,2"]
+|===
+|AsciiDoc |Word Output
+
+a|
+[source,asciidoc]
+----
+== Level 1 Heading
+=== Level 2 Heading
+==== Level 3 Heading
+===== Level 4 Heading
+====== Level 5 Heading
+----
+|Hierarchical headings with appropriate styles
+|===
+
+== Block Elements
+
+=== Paragraphs
+
+==== Simple Paragraph
+
+[source,asciidoc]
+----
+This is a simple paragraph.
+It can span multiple lines.
+
+This is another paragraph.
+----
+
+*Word Output*: Standard paragraph with default spacing
+
+==== Paragraph with Title
+
+[source,asciidoc]
+----
+.Paragraph Title
+This is a paragraph with a title.
+----
+
+*Word Output*: Title in bold followed by paragraph content
+
+=== Lists
+
+==== Unordered Lists
+
+[source,asciidoc]
+----
+* First item
+* Second item
+** Nested item
+** Another nested item
+* Third item
+----
+
+*Word Output*: Bulleted list with proper indentation
+
+==== Ordered Lists
+
+[source,asciidoc]
+----
+. First step
+. Second step
+.. Nested step
+.. Another nested step
+. Third step
+----
+
+*Word Output*: Numbered list with proper indentation
+
+==== Definition Lists
+
+[source,asciidoc]
+----
+Term 1::
+Definition for term 1
+
+Term 2::
+Definition for term 2
+----
+
+*Word Output*: Term in bold followed by definition
+
+==== Mixed Lists
+
+[source,asciidoc]
+----
+* Bullet item
+. Numbered item
+.. Nested numbered
+* Another bullet
+----
+
+*Word Output*: Properly formatted mixed list types
+
+=== Tables
+
+==== Simple Table
+
+[source,asciidoc]
+----
+|===
+|Column 1 |Column 2 |Column 3
+
+|Cell 1.1
+|Cell 1.2
+|Cell 1.3
+
+|Cell 2.1
+|Cell 2.2
+|Cell 2.3
+|===
+----
+
+*Word Output*: Table with borders and default styling
+
+==== Table with Header
+
+[source,asciidoc]
+----
+[cols="1,2,1"]
+|===
+|Name |Description |Status
+
+|Item 1
+|First item description
+|Active
+
+|Item 2
+|Second item description
+|Pending
+|===
+----
+
+*Word Output*: Table with header row in bold
+
+==== Table with Title
+
+[source,asciidoc]
+----
+.Table Title
+|===
+|Column 1 |Column 2
+
+|Data 1
+|Data 2
+|===
+----
+
+*Word Output*: Table with caption above
+
+==== Complex Table
+
+[source,asciidoc]
+----
+[cols="1,2,1",options="header,footer"]
+|===
+|Column 1 |Column 2 |Column 3
+
+|Row 1, Col 1
+|Row 1, Col 2
+|Row 1, Col 3
+
+|Row 2, Col 1
+|Row 2, Col 2
+|Row 2, Col 3
+
+|Footer 1
+|Footer 2
+|Footer 3
+|===
+----
+
+*Word Output*: Table with header and footer rows
+
+=== Code Blocks
+
+==== Listing Block
+
+[source,asciidoc]
+----
+[source,java]
+----
+public class Example {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}
+----
+----
+
+*Word Output*: Monospaced text block with code formatting
+
+==== Literal Block
+
+[source,asciidoc]
+----
+....
+Literal text block
+  Preserves spacing
+    and indentation
+....
+----
+
+*Word Output*: Monospaced text with preserved formatting
+
+==== Source Code with Syntax
+
+[source,asciidoc]
+----
+[source,python]
+----
+def hello():
+    print("Hello, World!")
+----
+----
+
+*Word Output*: Code block with language indicator
+
+=== Admonitions
+
+Admonitions are special blocks that draw attention to important information.
+
+==== Note
+
+[source,asciidoc]
+----
+NOTE: This is a note admonition.
+----
+
+*Word Output*: Note box with icon and highlighted background
+
+==== Tip
+
+[source,asciidoc]
+----
+TIP: This is a helpful tip.
+----
+
+*Word Output*: Tip box with icon and highlighted background
+
+==== Important
+
+[source,asciidoc]
+----
+IMPORTANT: This is important information.
+----
+
+*Word Output*: Important box with icon and highlighted background
+
+==== Warning
+
+[source,asciidoc]
+----
+WARNING: This is a warning.
+----
+
+*Word Output*: Warning box with icon and highlighted background
+
+==== Caution
+
+[source,asciidoc]
+----
+CAUTION: Proceed with caution.
+----
+
+*Word Output*: Caution box with icon and highlighted background
+
+==== Multi-line Admonitions
+
+[source,asciidoc]
+----
+[NOTE]
+====
+This is a multi-line note.
+
+It can contain multiple paragraphs,
+lists, and other content.
+====
+----
+
+*Word Output*: Admonition block containing multiple elements
+
+=== Examples
+
+[source,asciidoc]
+----
+.Example Title
+====
+This is an example block.
+It can contain any content.
+====
+----
+
+*Word Output*: Example box with title and bordered content
+
+=== Sidebars
+
+[source,asciidoc]
+----
+.Sidebar Title
+****
+This is sidebar content.
+It appears in a separate box.
+****
+----
+
+*Word Output*: Sidebar box with distinct styling
+
+=== Quotes
+
+==== Block Quote
+
+[source,asciidoc]
+----
+[quote, Author Name, Source]
+____
+This is a block quote.
+It can span multiple lines.
+____
+----
+
+*Word Output*: Indented quote with attribution
+
+==== Verse
+
+[source,asciidoc]
+----
+[verse, Poet Name, Poem Title]
+____
+Roses are red,
+Violets are blue,
+AsciiDoc is great,
+And so are you.
+____
+----
+
+*Word Output*: Verse block with preserved line breaks
+
+== Inline Elements
+
+=== Text Formatting
+
+==== Bold
+
+[source,asciidoc]
+----
+*bold text* or **bold text**
+----
+
+*Word Output*: **bold text**
+
+==== Italic
+
+[source,asciidoc]
+----
+_italic text_ or __italic text__
+----
+
+*Word Output*: _italic text_
+
+==== Monospace
+
+[source,asciidoc]
+----
+`monospace text` or ``monospace text``
+----
+
+*Word Output*: `monospace text`
+
+==== Combined Formatting
+
+[source,asciidoc]
+----
+*_bold and italic_*
+`*bold monospace*`
+----
+
+*Word Output*: Combined text styles
+
+==== Superscript
+
+[source,asciidoc]
+----
+E=mc^2^
+----
+
+*Word Output*: E=mc²
+
+==== Subscript
+
+[source,asciidoc]
+----
+H~2~O
+----
+
+*Word Output*: H₂O
+
+==== Highlight
+
+[source,asciidoc]
+----
+#highlighted text#
+----
+
+*Word Output*: Highlighted (marked) text
+
+==== Custom Styling
+
+[source,asciidoc]
+----
+[.custom-class]#styled text#
+----
+
+*Word Output*: Text with custom role/style applied
+
+=== Links
+
+==== External Links
+
+[source,asciidoc]
+----
+https://example.com
+https://example.com[Link Text]
+----
+
+*Word Output*: Clickable hyperlink
+
+==== Internal Cross-References
+
+[source,asciidoc]
+----
+[[section-id]]
+== Section Title
+
+See <<section-id>> for details.
+----
+
+*Word Output*: Internal document link
+
+==== Email Links
+
+[source,asciidoc]
+----
+mailto:user@example.com[Email Us]
+----
+
+*Word Output*: Email hyperlink
+
+=== Special Characters
+
+==== Symbols
+
+[source,asciidoc]
+----
+(C) Copyright
+(R) Registered
+(TM) Trademark
+----
+
+*Word Output*: © ® ™
+
+==== Arrows
+
+[source,asciidoc]
+----
+-> Right arrow
+<- Left arrow
+=> Double arrow
+----
+
+*Word Output*: → ← ⇒
+
+==== Ellipsis
+
+[source,asciidoc]
+----
+...
+----
+
+*Word Output*: …
+
+=== Line Breaks
+
+==== Hard Line Break
+
+[source,asciidoc]
+----
+Line 1 +
+Line 2
+----
+
+*Word Output*: Lines on separate lines without paragraph break
+
+==== Horizontal Rule
+
+[source,asciidoc]
+----
+'''
+----
+
+*Word Output*: Horizontal line separator
+
+== Advanced Elements
+
+=== Images
+
+[source,asciidoc]
+----
+image::path/to/image.png[Alt Text]
+
+.Image Caption
+image::diagram.png[Diagram,300,200]
+----
+
+*Word Output*: Embedded image with optional caption
+
+[NOTE]
+====
+Image support requires the image files to be accessible during conversion.
+====
+
+=== Includes
+
+[source,asciidoc]
+----
+include::chapter1.adoc[]
+----
+
+*Word Output*: Content from included file
+
+=== Comments
+
+[source,asciidoc]
+----
+// Single line comment
+
+////
+Multi-line comment
+Not visible in output
+////
+----
+
+*Word Output*: Comments are not included in output
+
+=== Page Breaks
+
+[source,asciidoc]
+----
+<<<
+----
+
+*Word Output*: Page break in Word document
+
+=== Table of Contents
+
+[source,asciidoc]
+----
+:toc:
+:toclevels: 3
+----
+
+*Word Output*: Automatic table of contents
+
+== Document Attributes
+
+=== Common Attributes
+
+[source,asciidoc]
+----
+:author: John Doe
+:email: john@example.com
+:revnumber: 1.0
+:revdate: 2024-01-01
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+----
+
+These attributes control document metadata and formatting.
+
+=== Custom Attributes
+
+[source,asciidoc]
+----
+:company: ACME Corp
+:version: 2.0
+
+Document for {company} version {version}
+----
+
+*Word Output*: Attribute values substituted in text
+
+== Arabic Text Support
+
+The converter includes special support for Arabic text:
+
+[source,asciidoc]
+----
+This is English text. هذا نص عربي. Back to English.
+----
+
+*Word Output*: Properly rendered Arabic text with correct directionality
+
+[NOTE]
+====
+Arabic text is automatically detected and rendered with:
+
+* Right-to-left direction
+* Appropriate font selection
+* Correct character shaping
+====
+
+== Limitations and Known Issues
+
+=== Partially Supported Elements
+
+* **Footnotes**: Basic support, may not preserve all formatting
+* **Bibliography**: Limited support
+* **Index**: Not currently supported
+* **Mathematical formulas**: Not supported (use images instead)
+
+=== Workarounds
+
+==== Complex Tables
+
+For very complex tables with merged cells, consider:
+
+* Simplifying the table structure
+* Using multiple simpler tables
+* Creating the table in Word after conversion
+
+==== Custom Styling
+
+For advanced styling needs:
+
+* Use Word styles after conversion
+* Apply custom templates
+* Post-process the DOCX file
+
+== Examples by Use Case
+
+=== Technical Documentation
+
+[source,asciidoc]
+----
+= API Reference
+:toc:
+:sectnums:
+
+== Introduction
+
+This document describes the API.
+
+=== Authentication
+
+[source,java]
+----
+Authentication auth = new Authentication(apiKey);
+----
+
+IMPORTANT: Keep your API key secure.
+
+=== Endpoints
+
+[cols="1,2,1"]
+|===
+|Method |Endpoint |Description
+
+|GET
+|/api/users
+|List all users
+
+|POST
+|/api/users
+|Create new user
+|===
+----
+
+=== User Manual
+
+[source,asciidoc]
+----
+= User Guide
+:icons: font
+
+== Getting Started
+
+Follow these steps:
+
+. Install the software
+. Configure settings
+. Start using
+
+TIP: Check the FAQ for common questions.
+
+== Features
+
+* Feature 1
+* Feature 2
+* Feature 3
+----
+
+=== Report Template
+
+[source,asciidoc]
+----
+= Monthly Report
+:author: Jane Smith
+:date: 2024-01-31
+
+== Executive Summary
+
+.Key Metrics
+|===
+|Metric |Value |Change
+
+|Revenue
+|$100K
+|+10%
+
+|Users
+|1000
+|+5%
+|===
+
+== Detailed Analysis
+
+[NOTE]
+====
+All figures are preliminary and subject to revision.
+====
+----
+
+== See Also
+
+* link:index.adoc[Main Documentation]
+* link:cli-guide.adoc[CLI User Guide]
+* link:api-reference.adoc[API Reference]
+* https://docs.asciidoctor.org/asciidoc/latest/[AsciiDoc Language Documentation]

--- a/docs/examples/basic-example.adoc
+++ b/docs/examples/basic-example.adoc
@@ -1,0 +1,100 @@
+= Basic Document Example
+John Doe <john@example.com>
+v1.0, 2024-01-01
+:toc:
+:icons: font
+
+== Introduction
+
+This is a basic example demonstrating common AsciiDoc elements that can be converted to Word format.
+
+== Text Formatting
+
+You can use *bold*, _italic_, and `monospace` text.
+
+You can also combine them: *_bold italic_* or `*bold monospace*`.
+
+== Lists
+
+=== Unordered Lists
+
+* First item
+* Second item
+** Nested item
+** Another nested item
+* Third item
+
+=== Ordered Lists
+
+. First step
+. Second step
+.. Nested step
+.. Another nested step
+. Third step
+
+=== Definition List
+
+Term 1::
+This is the definition for term 1.
+
+Term 2::
+This is the definition for term 2.
+
+== Tables
+
+.Sample Table
+[cols="1,2,1"]
+|===
+|Name |Description |Status
+
+|Item 1
+|First item description
+|Active
+
+|Item 2
+|Second item description
+|Pending
+
+|Item 3
+|Third item description
+|Complete
+|===
+
+== Code Blocks
+
+Here's a Java code example:
+
+[source,java]
+----
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}
+----
+
+== Admonitions
+
+NOTE: This is a note providing additional information.
+
+TIP: This is a helpful tip for the reader.
+
+IMPORTANT: This is important information that shouldn't be missed.
+
+WARNING: This is a warning about potential issues.
+
+CAUTION: Proceed with caution in this scenario.
+
+== Links
+
+Visit https://asciidoc.org[AsciiDoc] for more information.
+
+== Special Characters
+
+Copyright (C), Registered (R), Trademark (TM)
+
+Arrows: -> <- =>
+
+== Conclusion
+
+This example demonstrates the basic elements supported by the AsciiDoc to Word converter.

--- a/docs/examples/technical-doc.adoc
+++ b/docs/examples/technical-doc.adoc
@@ -1,0 +1,290 @@
+= REST API Documentation
+Technical Team <tech@example.com>
+v2.0, 2024-01-15
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+:source-highlighter: rouge
+
+== Overview
+
+This document describes the RESTful API for the Example Service.
+
+=== Base URL
+
+All API requests should be made to:
+
+----
+https://api.example.com/v2
+----
+
+=== Authentication
+
+IMPORTANT: All API requests require authentication using an API key.
+
+Include your API key in the request header:
+
+[source,http]
+----
+Authorization: Bearer YOUR_API_KEY
+----
+
+== Endpoints
+
+=== Users
+
+==== List Users
+
+Retrieve a list of all users.
+
+[cols="1,3"]
+|===
+|Method |GET
+|Endpoint |`/users`
+|Authentication |Required
+|===
+
+*Query Parameters:*
+
+[cols="1,1,2"]
+|===
+|Parameter |Type |Description
+
+|page
+|integer
+|Page number (default: 1)
+
+|limit
+|integer
+|Items per page (default: 20)
+
+|sort
+|string
+|Sort field (default: created_at)
+|===
+
+*Example Request:*
+
+[source,bash]
+----
+curl -X GET "https://api.example.com/v2/users?page=1&limit=10" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+----
+
+*Example Response:*
+
+[source,json]
+----
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "John Doe",
+      "email": "john@example.com",
+      "created_at": "2024-01-01T00:00:00Z"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "total": 100
+  }
+}
+----
+
+==== Create User
+
+Create a new user account.
+
+[cols="1,3"]
+|===
+|Method |POST
+|Endpoint |`/users`
+|Authentication |Required
+|===
+
+*Request Body:*
+
+[source,json]
+----
+{
+  "name": "Jane Smith",
+  "email": "jane@example.com",
+  "password": "secure_password"
+}
+----
+
+*Response:*
+
+[source,json]
+----
+{
+  "id": 2,
+  "name": "Jane Smith",
+  "email": "jane@example.com",
+  "created_at": "2024-01-15T10:30:00Z"
+}
+----
+
+WARNING: Passwords must be at least 8 characters long and include uppercase, lowercase, and numbers.
+
+=== Products
+
+==== Get Product
+
+Retrieve details for a specific product.
+
+[cols="1,3"]
+|===
+|Method |GET
+|Endpoint |`/products/{id}`
+|Authentication |Required
+|===
+
+*Path Parameters:*
+
+* `id` (integer) - Product ID
+
+*Example:*
+
+[source,bash]
+----
+curl -X GET "https://api.example.com/v2/products/123" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+----
+
+== Error Handling
+
+The API uses standard HTTP status codes:
+
+[cols="1,2,3"]
+|===
+|Code |Status |Description
+
+|200
+|OK
+|Request successful
+
+|201
+|Created
+|Resource created successfully
+
+|400
+|Bad Request
+|Invalid request parameters
+
+|401
+|Unauthorized
+|Missing or invalid authentication
+
+|404
+|Not Found
+|Resource not found
+
+|500
+|Server Error
+|Internal server error
+|===
+
+*Error Response Format:*
+
+[source,json]
+----
+{
+  "error": {
+    "code": "INVALID_REQUEST",
+    "message": "The request parameters are invalid",
+    "details": [
+      "Email is required",
+      "Password must be at least 8 characters"
+    ]
+  }
+}
+----
+
+== Rate Limiting
+
+NOTE: API requests are limited to 1000 requests per hour per API key.
+
+Rate limit information is included in response headers:
+
+----
+X-RateLimit-Limit: 1000
+X-RateLimit-Remaining: 999
+X-RateLimit-Reset: 1640000000
+----
+
+== Code Examples
+
+=== Python
+
+[source,python]
+----
+import requests
+
+API_KEY = "your_api_key"
+BASE_URL = "https://api.example.com/v2"
+
+headers = {
+    "Authorization": f"Bearer {API_KEY}",
+    "Content-Type": "application/json"
+}
+
+# Get users
+response = requests.get(f"{BASE_URL}/users", headers=headers)
+users = response.json()
+
+print(f"Found {len(users['data'])} users")
+----
+
+=== JavaScript
+
+[source,javascript]
+----
+const API_KEY = 'your_api_key';
+const BASE_URL = 'https://api.example.com/v2';
+
+async function getUsers() {
+  const response = await fetch(`${BASE_URL}/users`, {
+    headers: {
+      'Authorization': `Bearer ${API_KEY}`,
+      'Content-Type': 'application/json'
+    }
+  });
+  
+  const data = await response.json();
+  console.log(`Found ${data.data.length} users`);
+}
+
+getUsers();
+----
+
+== Best Practices
+
+TIP: Follow these best practices for optimal API usage:
+
+. *Use HTTPS*: Always use HTTPS for API requests
+. *Handle Errors*: Implement proper error handling
+. *Cache Responses*: Cache responses when appropriate
+. *Respect Rate Limits*: Monitor and respect rate limits
+. *Keep Keys Secure*: Never expose API keys in client-side code
+
+== Changelog
+
+=== Version 2.0 (2024-01-15)
+
+* Added pagination support
+* Improved error messages
+* Added rate limiting
+* New product endpoints
+
+=== Version 1.0 (2023-06-01)
+
+* Initial release
+* Basic user management
+* Authentication system
+
+== Support
+
+For API support, contact: api-support@example.com

--- a/docs/examples/user-guide.adoc
+++ b/docs/examples/user-guide.adoc
@@ -1,0 +1,342 @@
+= Software User Guide
+Documentation Team
+v3.5, 2024-01-20
+:toc: left
+:toclevels: 2
+:sectnums:
+:icons: font
+
+== Welcome
+
+Welcome to the Software User Guide. This guide will help you get started and make the most of the application.
+
+== Getting Started
+
+=== System Requirements
+
+Before installing, ensure your system meets these requirements:
+
+* *Operating System*: Windows 10+, macOS 10.15+, or Linux
+* *Memory*: Minimum 4GB RAM (8GB recommended)
+* *Disk Space*: 500MB free space
+* *Display*: 1280x720 or higher resolution
+
+=== Installation
+
+==== Windows
+
+. Download the installer from https://example.com/download
+. Run the `.exe` file
+. Follow the installation wizard
+. Launch the application from the Start menu
+
+==== macOS
+
+. Download the `.dmg` file
+. Open the disk image
+. Drag the application to your Applications folder
+. Launch from Applications
+
+==== Linux
+
+[source,bash]
+----
+# Ubuntu/Debian
+sudo apt-get install example-app
+
+# Fedora/RHEL
+sudo dnf install example-app
+----
+
+=== First Launch
+
+When you first launch the application:
+
+. You'll see the welcome screen
+. Click "Create Account" or "Sign In"
+. Complete the setup wizard
+. You're ready to start!
+
+TIP: Take the tour on first launch to learn about key features.
+
+== Main Features
+
+=== Dashboard
+
+The dashboard is your central hub for all activities.
+
+.Dashboard Components
+[cols="1,3"]
+|===
+|Component |Description
+
+|Quick Actions
+|Frequently used actions for fast access
+
+|Recent Items
+|Your most recently accessed items
+
+|Notifications
+|Important updates and alerts
+
+|Statistics
+|Overview of your activity and metrics
+|===
+
+=== Creating Projects
+
+To create a new project:
+
+. Click the *New Project* button
+. Enter project details:
+.. Project name
+.. Description
+.. Category
+. Choose a template (optional)
+. Click *Create*
+
+[NOTE]
+====
+Project names must be unique within your workspace.
+====
+
+=== Managing Files
+
+==== Uploading Files
+
+You can upload files in several ways:
+
+* Drag and drop files into the window
+* Click *Upload* and select files
+* Use the keyboard shortcut: `Ctrl+U` (Windows/Linux) or `Cmd+U` (macOS)
+
+*Supported file types:*
+
+* Documents: `.pdf`, `.docx`, `.txt`
+* Images: `.jpg`, `.png`, `.gif`
+* Archives: `.zip`, `.tar.gz`
+
+IMPORTANT: Maximum file size is 100MB per file.
+
+==== Organizing Files
+
+Use folders to organize your files:
+
+. Right-click in the file area
+. Select *New Folder*
+. Name your folder
+. Drag files into the folder
+
+=== Collaboration
+
+==== Sharing
+
+To share a project with others:
+
+. Open the project
+. Click the *Share* button
+. Enter email addresses
+. Set permissions:
+** *View*: Can only view content
+** *Edit*: Can modify content
+** *Admin*: Full control
+. Click *Send Invitations*
+
+==== Comments
+
+Add comments to collaborate:
+
+. Select the item to comment on
+. Click the comment icon
+. Type your comment
+. Click *Post*
+
+TIP: Use @mentions to notify specific team members.
+
+== Advanced Features
+
+=== Keyboard Shortcuts
+
+.Common Shortcuts
+[cols="1,1,2"]
+|===
+|Action |Windows/Linux |macOS
+
+|New Project
+|Ctrl+N
+|Cmd+N
+
+|Save
+|Ctrl+S
+|Cmd+S
+
+|Search
+|Ctrl+F
+|Cmd+F
+
+|Upload
+|Ctrl+U
+|Cmd+U
+
+|Help
+|F1
+|F1
+|===
+
+=== Automation
+
+Create automated workflows:
+
+. Go to *Settings* > *Automation*
+. Click *New Workflow*
+. Define triggers:
+** When a file is uploaded
+** When a project is created
+** On a schedule
+. Define actions:
+** Send notification
+** Move to folder
+** Run script
+. Save and activate
+
+=== Integration
+
+Connect with other tools:
+
+* *Cloud Storage*: Dropbox, Google Drive, OneDrive
+* *Communication*: Slack, Microsoft Teams
+* *Project Management*: Jira, Trello
+* *Version Control*: GitHub, GitLab
+
+== Troubleshooting
+
+=== Common Issues
+
+==== Application Won't Start
+
+*Problem*: Application fails to launch
+
+*Solutions*:
+
+. Check system requirements
+. Restart your computer
+. Reinstall the application
+. Check antivirus settings
+
+==== Files Won't Upload
+
+*Problem*: File upload fails
+
+*Solutions*:
+
+. Check file size (max 100MB)
+. Verify file type is supported
+. Check internet connection
+. Clear browser cache (web version)
+
+==== Sync Issues
+
+*Problem*: Changes not syncing
+
+*Solutions*:
+
+. Check internet connection
+. Sign out and sign back in
+. Force sync: *Settings* > *Sync* > *Force Sync*
+. Contact support if issue persists
+
+WARNING: Forcing sync may overwrite local changes.
+
+=== Getting Help
+
+If you need assistance:
+
+* *Help Center*: https://help.example.com
+* *Email Support*: support@example.com
+* *Live Chat*: Available 9 AM - 5 PM EST
+* *Community Forum*: https://community.example.com
+
+== Tips and Tricks
+
+[TIP]
+====
+*Power User Tips:*
+
+* Use keyboard shortcuts for faster navigation
+* Create templates for recurring projects
+* Set up automation for repetitive tasks
+* Use tags to organize and find items quickly
+* Enable dark mode in Settings for reduced eye strain
+====
+
+== Privacy and Security
+
+=== Data Protection
+
+Your data is protected with:
+
+* *Encryption*: AES-256 encryption at rest and in transit
+* *Backups*: Daily automated backups
+* *Access Control*: Role-based permissions
+* *Audit Logs*: Complete activity tracking
+
+=== Best Practices
+
+. Use a strong, unique password
+. Enable two-factor authentication
+. Review sharing permissions regularly
+. Don't share your account credentials
+. Log out on shared computers
+
+== Appendix
+
+=== Glossary
+
+Project::
+A container for related files and activities
+
+Workspace::
+Your personal or team environment
+
+Template::
+A pre-configured project structure
+
+Workflow::
+An automated sequence of actions
+
+=== Keyboard Shortcuts Reference
+
+See the complete list in *Help* > *Keyboard Shortcuts* or press `?` in the application.
+
+=== Version History
+
+[cols="1,1,3"]
+|===
+|Version |Date |Changes
+
+|3.5
+|2024-01-20
+|Added automation features, improved performance
+
+|3.0
+|2023-10-15
+|New dashboard design, collaboration features
+
+|2.0
+|2023-04-01
+|Cloud sync, mobile apps
+
+|1.0
+|2022-12-01
+|Initial release
+|===
+
+== Contact
+
+For questions or feedback:
+
+* Email: feedback@example.com
+* Twitter: @exampleapp
+* Website: https://example.com
+
+Thank you for using our software!

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,0 +1,138 @@
+= AsciiDoc to Word Converter
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+:source-highlighter: rouge
+:version: 0.5.5-SNAPSHOT
+
+== Overview
+
+The AsciiDoc to Word Converter is a powerful library and command-line tool that converts AsciiDoc documents into Office 365 Word® (DOCX) format. This tool provides a seamless way to create professional Word documents from AsciiDoc source files while preserving formatting, structure, and styling.
+
+=== Key Features
+
+* **Full AsciiDoc Support**: Convert AsciiDoc documents with comprehensive element support
+* **DocBook Pipeline**: Uses DocBook as an intermediate format for robust conversion
+* **Rich Formatting**: Preserves text formatting, lists, tables, admonitions, and more
+* **Arabic Text Support**: Built-in support for Arabic text rendering
+* **Command-Line Interface**: Easy-to-use CLI for batch processing and automation
+* **Programmatic API**: Use as a library in your Java applications
+* **Customizable Output**: Control output paths, styling, and document structure
+
+=== How It Works
+
+The conversion process follows a three-stage pipeline:
+
+[source]
+----
+AsciiDoc → DocBook XML → DOCX (Word)
+----
+
+1. **AsciiDoc to DocBook**: The AsciiDoctor library converts your AsciiDoc source to DocBook XML
+2. **DocBook to DOCX**: The custom conversion engine transforms DocBook elements into Word document structures
+3. **Output**: A fully formatted DOCX file ready to open in Microsoft Word or compatible applications
+
+== Quick Start
+
+=== Prerequisites
+
+* Java 17 or higher
+* Gradle 9.4.1 (included via wrapper)
+
+=== Building from Source
+
+Clone the repository and build the project:
+
+[source,bash]
+----
+git clone https://github.com/AlphaSystemSolution/docbook-2-docx.git
+cd docbook-2-docx
+./gradlew build
+----
+
+=== Creating the CLI Tool
+
+Build the shadow JAR (fat JAR with all dependencies):
+
+[source,bash]
+----
+./gradlew :asciidoc-docx-cli:shadowJar
+----
+
+The executable JAR will be created at:
+----
+asciidoc-docx-cli/build/libs/asciidoc-docx-cli-{version}-all.jar
+----
+
+=== Basic Usage
+
+Convert an AsciiDoc file to Word:
+
+[source,bash]
+----
+java -jar asciidoc-docx-cli-0.5.5-SNAPSHOT-all.jar -s input.adoc
+----
+
+This creates `input.docx` in the same directory as the source file.
+
+== Documentation
+
+=== User Documentation
+
+* link:cli-guide.adoc[CLI User Guide] - Complete command-line interface documentation
+* link:elements-reference.adoc[Supported Elements] - Reference for all supported AsciiDoc elements
+
+=== Developer Documentation
+
+* link:developer-guide.adoc[Developer Guide] - Architecture, modules, and contribution guidelines
+* link:api-reference.adoc[API Reference] - Programmatic usage and library integration
+
+== Project Modules
+
+The project is organized into six modules:
+
+[cols="1,3"]
+|===
+|Module |Description
+
+|`docbook-2-docx-common`
+|Shared models, utilities, and common interfaces
+
+|`docbook-model`
+|JAXB-generated DocBook XML model classes
+
+|`asciidoctor-adapter`
+|AsciiDoc to DocBook conversion using AsciidoctorJ
+
+|`docbook-2-docx`
+|Core DocBook to DOCX conversion engine
+
+|`arabic-handler`
+|Arabic text processing and rendering support
+
+|`asciidoc-docx-cli`
+|Command-line interface application
+|===
+
+== Examples
+
+See the link:examples/[examples directory] for sample AsciiDoc files demonstrating various features.
+
+== License
+
+This project is licensed under the Apache License 2.0. See link:../LICENSE.md[LICENSE.md] for details.
+
+== Version
+
+Current version: *{version}*
+
+== Support
+
+For issues, questions, or contributions, please visit the project repository.
+
+== See Also
+
+* https://asciidoc.org/[AsciiDoc Documentation]
+* https://asciidoctor.org/[Asciidoctor Project]
+* https://docbook.org/[DocBook Project]


### PR DESCRIPTION
Add detailed API documentation covering programmatic usage of the converter library, including complete examples for DocumentConverter, DocumentBuilder, and AsciiDocumentInfo classes. Include documentation index with links to all guides, examples, and quick start instructions for converting documentation files to Word format.